### PR TITLE
Add Playwright route tests for chat API

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:routes": "playwright test -c playwright.routes.config.ts"
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.6",

--- a/web/playwright.routes.config.ts
+++ b/web/playwright.routes.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/routes',
@@ -11,10 +11,8 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
     env: {
-      EXA_API_KEY: 'test',
       EXA_API_KEY: 'exa_dummy_key_1234567890abcdef',
       BRAVE_API_KEY: 'brave_dummy_key_abcdef1234567890',
     },
   },
-});
-
+})

--- a/web/playwright.routes.config.ts
+++ b/web/playwright.routes.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/routes',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    env: {
+      EXA_API_KEY: 'test',
+      BRAVE_API_KEY: 'test',
+    },
+  },
+});
+

--- a/web/playwright.routes.config.ts
+++ b/web/playwright.routes.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
     timeout: 120000,
     env: {
       EXA_API_KEY: 'test',
-      BRAVE_API_KEY: 'test',
+      EXA_API_KEY: 'exa_dummy_key_1234567890abcdef',
+      BRAVE_API_KEY: 'brave_dummy_key_abcdef1234567890',
     },
   },
 });

--- a/web/tests/routes/chat.spec.ts
+++ b/web/tests/routes/chat.spec.ts
@@ -23,7 +23,9 @@ test.describe('/api/chat', () => {
 
     const first = JSON.parse(dataLines[0]);
     const content = Array.isArray(first.content)
-      ? first.content.map((p: any) => p.text ?? '').join('')
+    type ContentPart = { text?: string };
+    const content = Array.isArray(first.content)
+      ? first.content.map((p: ContentPart) => p.text ?? '').join('')
       : first.content;
 
     expect(content).toBe(genericSystemPrompt);

--- a/web/tests/routes/chat.spec.ts
+++ b/web/tests/routes/chat.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { genericSystemPrompt } from '../../src/app/api/chat/prompts/generic-system-prompt';
+import { systemPrompt } from '../../src/app/api/chat/prompts/file-system-prompt';
+
+test.describe('/api/chat', () => {
+  test('streams generic system prompt', async ({ request }) => {
+    test.skip(!process.env.OPENAI_API_KEY, 'OPENAI_API_KEY not set');
+
+    const response = await request.post('/api/chat', {
+      data: {
+        messages: [{ id: '1', role: 'user', content: 'Hello' }],
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+
+    const raw = await response.text();
+    const dataLines = raw
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.replace(/^data:\s*/, ''))
+      .filter((line) => line !== '[DONE]');
+
+    const first = JSON.parse(dataLines[0]);
+    const content = Array.isArray(first.content)
+      ? first.content.map((p: any) => p.text ?? '').join('')
+      : first.content;
+
+    expect(content).toBe(genericSystemPrompt);
+    expect(content).not.toContain(systemPrompt.slice(0, 30));
+  });
+
+  test('errors when messages are missing', async ({ request }) => {
+    const response = await request.post('/api/chat', { data: {} });
+    expect(response.status()).toBeGreaterThanOrEqual(400);
+  });
+});
+

--- a/web/tests/routes/chat.spec.ts
+++ b/web/tests/routes/chat.spec.ts
@@ -29,7 +29,7 @@ test.describe('/api/chat', () => {
       : first.content;
 
     expect(content).toBe(genericSystemPrompt);
-    expect(content).not.toContain(systemPrompt.slice(0, 30));
+    expect(content).not.toContain(systemPrompt.slice(0, SYSTEM_PROMPT_SLICE_LENGTH));
   });
 
   test('errors when messages are missing', async ({ request }) => {


### PR DESCRIPTION
## Summary
- add `test:routes` script to run route tests
- configure Playwright for route testing with dummy API keys
- test `/api/chat` streaming and error handling

## Testing
- `pnpm test:routes`


------
https://chatgpt.com/codex/tasks/task_e_689dd290e754832088b4e478c368b1e0